### PR TITLE
Add monorepo skeleton and docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,23 @@ This project follows formal SDLC practices:
 - Observability and continuous evolution
 
 See `docs/manifesto.md` for more details.
+
+## 🚀 Local development (Docker)
+
+Spin up the full stack locally with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+Services and health checks:
+- PostgreSQL: `localhost:5432` (db: `fiscal`, user: `fiscal`, password: `fiscal`)
+- Laravel API placeholder: `http://localhost:8001/health`
+- FastAPI engine placeholder: `http://localhost:8002/health`
+- React web placeholder: `http://localhost:5173`
+
+Shut everything down:
+
+```bash
+docker compose down -v
+```

--- a/apps/api-laravel/Dockerfile
+++ b/apps/api-laravel/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:8.2-cli
+
+WORKDIR /app
+
+COPY router.php ./router.php
+
+EXPOSE 8000
+
+CMD ["php", "-S", "0.0.0.0:8000", "router.php"]

--- a/apps/api-laravel/router.php
+++ b/apps/api-laravel/router.php
@@ -1,0 +1,15 @@
+<?php
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+if ($path === '/health') {
+    header('Content-Type: application/json');
+    echo json_encode([
+        'status' => 'ok',
+        'service' => 'api-laravel',
+    ]);
+    return;
+}
+
+http_response_code(200);
+header('Content-Type: text/plain');
+echo "Laravel API placeholder. Try /health\n";

--- a/apps/engine-fastapi/Dockerfile
+++ b/apps/engine-fastapi/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py ./main.py
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/engine-fastapi/main.py
+++ b/apps/engine-fastapi/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Engine FastAPI Placeholder")
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "service": "engine-fastapi"}
+
+
+@app.get("/")
+def root():
+    return {"message": "FastAPI engine placeholder", "health": "/health"}

--- a/apps/engine-fastapi/requirements.txt
+++ b/apps/engine-fastapi/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6

--- a/apps/web-react/Dockerfile
+++ b/apps/web-react/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json vite.config.js index.html ./
+COPY src ./src
+
+RUN npm install
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev"]

--- a/apps/web-react/index.html
+++ b/apps/web-react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fiscal Intelligence Platform</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/apps/web-react/package.json
+++ b/apps/web-react/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "fiscal-web-react",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 5173",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 5173"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.4.2"
+  }
+}

--- a/apps/web-react/src/App.jsx
+++ b/apps/web-react/src/App.jsx
@@ -1,0 +1,15 @@
+import "./styles.css";
+
+export default function App() {
+  return (
+    <main className="container">
+      <h1>Fiscal Intelligence Platform</h1>
+      <p>React web placeholder is running.</p>
+      <div className="health">
+        <span className="label">Health:</span>
+        <span className="value">OK</span>
+      </div>
+      <p className="hint">Use this container as the starting point for the UI.</p>
+    </main>
+  );
+}

--- a/apps/web-react/src/main.jsx
+++ b/apps/web-react/src/main.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.jsx";
+
+createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web-react/src/styles.css
+++ b/apps/web-react/src/styles.css
@@ -1,0 +1,38 @@
+:root {
+  font-family: "Inter", system-ui, sans-serif;
+  color: #0f172a;
+  background: #f8fafc;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  max-width: 720px;
+  margin: 8vh auto 0;
+  padding: 2.5rem;
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.15);
+}
+
+h1 {
+  margin-bottom: 0.5rem;
+}
+
+.health {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #dcfce7;
+  color: #166534;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.hint {
+  margin-top: 1.5rem;
+  color: #475569;
+}

--- a/apps/web-react/vite.config.js
+++ b/apps/web-react/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 5173,
+  },
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: fiscal
+      POSTGRES_USER: fiscal
+      POSTGRES_PASSWORD: fiscal
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  api-laravel:
+    build:
+      context: ./apps/api-laravel
+    ports:
+      - "8001:8000"
+    depends_on:
+      - postgres
+
+  engine-fastapi:
+    build:
+      context: ./apps/engine-fastapi
+    ports:
+      - "8002:8000"
+    depends_on:
+      - postgres
+
+  web-react:
+    build:
+      context: ./apps/web-react
+    ports:
+      - "5173:5173"
+    depends_on:
+      - api-laravel
+      - engine-fastapi
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
### Motivation

- Provide an initial monorepo structure to host the API, engine, and web UI so local development can run all services together. 
- Include minimal, safe placeholders for each app that expose a health endpoint or page to satisfy early integration and orchestration checks.
- Add a root Docker Compose file to start a shared Postgres instance and the three app containers for local development.

### Description

- Added app folders `apps/api-laravel`, `apps/engine-fastapi`, and `apps/web-react` with minimal placeholder implementations and health endpoints/pages (see `apps/api-laravel/router.php`, `apps/engine-fastapi/main.py`, and `apps/web-react/src/App.jsx`).
- Added Dockerfiles for each app to allow containerized builds (`apps/api-laravel/Dockerfile`, `apps/engine-fastapi/Dockerfile`, `apps/web-react/Dockerfile`).
- Added `apps/engine-fastapi/requirements.txt` with `fastapi` and `uvicorn` pinned for the placeholder engine. 
- Added a root `docker-compose.yml` that defines `postgres` plus the three app services and a persistent `postgres_data` volume. 
- Updated `README.md` with local development instructions and the health endpoints and shutdown commands (`docker compose up --build` and `docker compose down -v`).

### Testing

- Attempted `npm install` inside `apps/web-react` to validate the React container build, but it failed with a `403 Forbidden` from the npm registry, so the Node dependency install could not be validated. 
- No other automated tests or container builds were executed in this environment after the dependency install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971432145288329aa2352433339891b)